### PR TITLE
Version 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 - Spigot 1.15+
 - (Optional) Vault (所持金のバックアップ機能)
 - (Optional) mcMMO (スキルレベルのバックアップ機能)
-- (Optional) [UserAPI](https://github.com/okocraft/UserAPI) (mcid → uuid 検索用, 未導入の場合は Bukkit から直接取得)
 
 ## Usage
 
@@ -30,7 +29,7 @@
 /db backup <target>: プレイヤーのバックアップを取ります。
 /db clean: 期限切れのバックアップファイルを削除します (起動毎に自動実行)
 /db rollback <type> <target> <file>: 指定したデータを戻します。
-/db search <target> <material> {page}: プレイヤーのバックアップから指定した Material のアイテムを検索します。
+/db search {offline} <target> <material> {page}: プレイヤーのバックアップから指定した Material のアイテムを検索します。
 /db show {offline} <type> <target> <file>: 指定したデータの内訳を表示します。
 ※ offline と指定しない限り、オンラインプレイヤーとして検索されます。
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.okocraft.databackup</groupId>
     <artifactId>databackup</artifactId>
-    <version>2.0</version>
+    <version>2.1</version>
 
     <name>DataBackup</name>
     <url>https://github.com/okocraft/DataBackup</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.okocraft.databackup</groupId>
     <artifactId>databackup</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
 
     <name>DataBackup</name>
     <url>https://github.com/okocraft/DataBackup</url>

--- a/src/main/java/net/okocraft/databackup/command/DataBackupCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/DataBackupCommand.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -83,7 +84,7 @@ public class DataBackupCommand extends AbstractCommand {
             return subCommandHolder.getSubCommands()
                     .stream()
                     .map(Command::getName)
-                    .filter(cmd -> cmd.startsWith(firstArgument.get()))
+                    .filter(cmd -> cmd.toLowerCase().startsWith(firstArgument.get().toLowerCase()))
                     .sorted()
                     .collect(Collectors.toList());
         } else {

--- a/src/main/java/net/okocraft/databackup/command/DataBackupCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/DataBackupCommand.java
@@ -20,10 +20,8 @@ import net.okocraft.databackup.command.subcommand.ShowCommand;
 import net.okocraft.databackup.lang.DefaultMessage;
 import net.okocraft.databackup.lang.MessageProvider;
 import org.bukkit.command.PluginCommand;
-import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -82,10 +80,12 @@ public class DataBackupCommand extends AbstractCommand {
         Argument firstArgument = context.getArguments().get(0);
 
         if (args.size() == 1) {
-            return StringUtil.copyPartialMatches(
-                    firstArgument.get(),
-                    subCommandHolder.getSubCommands().stream().map(Command::getName).collect(Collectors.toList()),
-                    new ArrayList<>());
+            return subCommandHolder.getSubCommands()
+                    .stream()
+                    .map(Command::getName)
+                    .filter(cmd -> cmd.startsWith(firstArgument.get()))
+                    .sorted()
+                    .collect(Collectors.toList());
         } else {
             return subCommandHolder
                     .searchOptional(firstArgument)

--- a/src/main/java/net/okocraft/databackup/command/StartsWithIgnoreCase.java
+++ b/src/main/java/net/okocraft/databackup/command/StartsWithIgnoreCase.java
@@ -1,0 +1,13 @@
+package net.okocraft.databackup.command;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+import java.util.function.Predicate;
+
+public final class StartsWithIgnoreCase {
+
+    public static @NotNull Predicate<String> prefix(@NotNull String prefix) {
+        return str -> str.toLowerCase(Locale.ROOT).startsWith(prefix.toLowerCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/net/okocraft/databackup/command/subcommand/BackupCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/BackupCommand.java
@@ -14,16 +14,14 @@ import net.okocraft.databackup.storage.PlayerDataFile;
 import net.okocraft.databackup.task.BackupTask;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 public class BackupCommand extends AbstractCommand {
 
@@ -72,14 +70,18 @@ public class BackupCommand extends AbstractCommand {
             return Collections.emptyList();
         }
 
-        List<String> result = new LinkedList<>();
+        var secondArgument = args.get(1).get();
+
+        var result =
+                plugin.getServer().getOnlinePlayers()
+                        .stream()
+                        .map(HumanEntity::getName)
+                        .filter(player -> player.startsWith(secondArgument))
+                        .collect(Collectors.toList());
 
         result.add("all");
-        plugin.getServer().getOnlinePlayers().stream().map(HumanEntity::getName).forEach(result::add);
 
-        Argument secondArgument = args.get(1);
-
-        return StringUtil.copyPartialMatches(secondArgument.get(), result, new ArrayList<>());
+        return result;
     }
 
     @NotNull

--- a/src/main/java/net/okocraft/databackup/command/subcommand/BackupCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/BackupCommand.java
@@ -7,6 +7,7 @@ import com.github.siroshun09.mccommand.common.argument.Argument;
 import com.github.siroshun09.mccommand.common.context.CommandContext;
 import com.github.siroshun09.mccommand.common.sender.Sender;
 import net.okocraft.databackup.DataBackup;
+import net.okocraft.databackup.command.StartsWithIgnoreCase;
 import net.okocraft.databackup.lang.DefaultMessage;
 import net.okocraft.databackup.lang.MessageProvider;
 import net.okocraft.databackup.lang.Placeholders;
@@ -76,7 +77,7 @@ public class BackupCommand extends AbstractCommand {
                 plugin.getServer().getOnlinePlayers()
                         .stream()
                         .map(HumanEntity::getName)
-                        .filter(player -> player.startsWith(secondArgument))
+                        .filter(StartsWithIgnoreCase.prefix(secondArgument))
                         .collect(Collectors.toList());
 
         result.add("all");

--- a/src/main/java/net/okocraft/databackup/command/subcommand/RollbackCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/RollbackCommand.java
@@ -8,6 +8,7 @@ import com.github.siroshun09.mccommand.common.argument.Argument;
 import com.github.siroshun09.mccommand.common.context.CommandContext;
 import com.github.siroshun09.mccommand.common.sender.Sender;
 import net.okocraft.databackup.DataBackup;
+import net.okocraft.databackup.command.StartsWithIgnoreCase;
 import net.okocraft.databackup.data.DataType;
 import net.okocraft.databackup.data.impl.BackupTimeValue;
 import net.okocraft.databackup.lang.DefaultMessage;
@@ -124,7 +125,7 @@ public class RollbackCommand extends AbstractCommand {
             return plugin.getDataTypeRegistry().getRegisteredDataType()
                     .stream()
                     .map(DataType::getName)
-                    .filter(str -> str.startsWith(secondArgument))
+                    .filter(StartsWithIgnoreCase.prefix(secondArgument))
                     .sorted()
                     .collect(Collectors.toList());
         }
@@ -135,7 +136,7 @@ public class RollbackCommand extends AbstractCommand {
             return plugin.getServer().getOnlinePlayers()
                     .stream()
                     .map(HumanEntity::getName)
-                    .filter(str -> str.startsWith(thirdArgument))
+                    .filter(StartsWithIgnoreCase.prefix(thirdArgument))
                     .sorted()
                     .collect(Collectors.toUnmodifiableList());
         }
@@ -150,7 +151,7 @@ public class RollbackCommand extends AbstractCommand {
                 return plugin.getStorage().getPlayerDataYamlFiles(target.getUniqueId())
                         .map(Path::getFileName)
                         .map(Path::toString)
-                        .filter(path -> path.startsWith(fourthArgument))
+                        .filter(StartsWithIgnoreCase.prefix(fourthArgument))
                         .sorted()
                         .collect(Collectors.toUnmodifiableList());
             }

--- a/src/main/java/net/okocraft/databackup/command/subcommand/RollbackCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/RollbackCommand.java
@@ -16,13 +16,11 @@ import net.okocraft.databackup.lang.Placeholders;
 import net.okocraft.databackup.storage.PlayerDataFile;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -121,45 +119,40 @@ public class RollbackCommand extends AbstractCommand {
         }
 
         if (args.size() == 2) {
-            Argument secondArgument = args.get(1);
+            var secondArgument = args.get(1).get();
 
-            return StringUtil.copyPartialMatches(
-                    secondArgument.get(),
-                    plugin.getDataTypeRegistry().getRegisteredDataType()
-                            .stream()
-                            .map(DataType::getName)
-                            .collect(Collectors.toList()),
-                    new ArrayList<>()
-            );
+            return plugin.getDataTypeRegistry().getRegisteredDataType()
+                    .stream()
+                    .map(DataType::getName)
+                    .filter(str -> str.startsWith(secondArgument))
+                    .sorted()
+                    .collect(Collectors.toList());
         }
 
         if (args.size() == 3) {
-            Argument thirdArgument = args.get(2);
+            var thirdArgument = args.get(2).get();
 
-            return StringUtil.copyPartialMatches(
-                    thirdArgument.get(),
-                    plugin.getServer().getOnlinePlayers().stream()
-                            .map(HumanEntity::getName)
-                            .collect(Collectors.toUnmodifiableList()),
-                    new ArrayList<>()
-            );
+            return plugin.getServer().getOnlinePlayers()
+                    .stream()
+                    .map(HumanEntity::getName)
+                    .filter(str -> str.startsWith(thirdArgument))
+                    .sorted()
+                    .collect(Collectors.toUnmodifiableList());
         }
 
         if (args.size() == 4) {
-            Argument thirdArgument = args.get(2);
-            Player target = BukkitParser.PLAYER.parse(thirdArgument);
+            var thirdArgument = args.get(2);
+            var target = BukkitParser.PLAYER.parse(thirdArgument);
 
             if (target != null) {
-                Argument fourthArgument = args.get(3);
+                var fourthArgument = args.get(3).get();
 
-                return StringUtil.copyPartialMatches(
-                        fourthArgument.get(),
-                        plugin.getStorage().getPlayerDataYamlFiles(target.getUniqueId())
-                                .map(Path::getFileName)
-                                .map(Path::toString)
-                                .collect(Collectors.toUnmodifiableList()),
-                        new ArrayList<>()
-                );
+                return plugin.getStorage().getPlayerDataYamlFiles(target.getUniqueId())
+                        .map(Path::getFileName)
+                        .map(Path::toString)
+                        .filter(path -> path.startsWith(fourthArgument))
+                        .sorted()
+                        .collect(Collectors.toUnmodifiableList());
             }
         }
 

--- a/src/main/java/net/okocraft/databackup/command/subcommand/SearchCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/SearchCommand.java
@@ -8,6 +8,7 @@ import com.github.siroshun09.mccommand.common.argument.Argument;
 import com.github.siroshun09.mccommand.common.argument.parser.BasicParser;
 import com.github.siroshun09.mccommand.common.context.CommandContext;
 import net.okocraft.databackup.DataBackup;
+import net.okocraft.databackup.command.StartsWithIgnoreCase;
 import net.okocraft.databackup.data.BackupData;
 import net.okocraft.databackup.data.ItemSearchable;
 import net.okocraft.databackup.gui.DataBackupGui;
@@ -70,7 +71,7 @@ public class SearchCommand extends AbstractCommand {
         }
 
         if (args.get(1).get().equalsIgnoreCase("offline")) {
-            if (args.size() < 5) {
+            if (args.size() < 4) {
                 MessageProvider.sendMessageWithPrefix(DefaultMessage.COMMAND_SEARCH_USAGE, sender);
                 return CommandResult.INVALID_ARGUMENTS;
             }
@@ -105,13 +106,13 @@ public class SearchCommand extends AbstractCommand {
                             .map(Bukkit::getOfflinePlayer)
                             .map(OfflinePlayer::getName)
                             .filter(Objects::nonNull)
-                            .filter(player -> player.startsWith(secondArgument))
+                            .filter(StartsWithIgnoreCase.prefix(secondArgument))
                             .sorted()
                             .collect(Collectors.toUnmodifiableList()) :
                     plugin.getServer().getOnlinePlayers()
                             .stream()
                             .map(HumanEntity::getName)
-                            .filter(player -> player.startsWith(secondArgument))
+                            .filter(StartsWithIgnoreCase.prefix(secondArgument))
                             .sorted()
                             .collect(Collectors.toList());
 
@@ -127,7 +128,7 @@ public class SearchCommand extends AbstractCommand {
 
             return Arrays.stream(Material.values())
                     .map(Enum::name)
-                    .filter(material -> material.startsWith(thirdArgument))
+                    .filter(StartsWithIgnoreCase.prefix(thirdArgument))
                     .sorted()
                     .collect(Collectors.toUnmodifiableList());
         }
@@ -136,7 +137,7 @@ public class SearchCommand extends AbstractCommand {
             var fourthArgument = args.get(3).get();
 
             return PAGES.stream()
-                    .filter(page -> page.startsWith(fourthArgument))
+                    .filter(StartsWithIgnoreCase.prefix(fourthArgument))
                     .collect(Collectors.toUnmodifiableList());
         }
 

--- a/src/main/java/net/okocraft/databackup/command/subcommand/SearchCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/SearchCommand.java
@@ -16,6 +16,7 @@ import net.okocraft.databackup.lang.MessageProvider;
 import net.okocraft.databackup.lang.Placeholders;
 import net.okocraft.databackup.storage.PlayerDataFile;
 import net.okocraft.databackup.storage.Storage;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.HumanEntity;
@@ -29,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class SearchCommand extends AbstractCommand {
 
@@ -100,13 +100,16 @@ public class SearchCommand extends AbstractCommand {
             var secondArgument = args.get(1).get();
 
             var result = offline ?
-                    Stream.of(plugin.getServer().getOfflinePlayers())
+                    plugin.getStorage().getBackedUpPlayers()
+                            .stream()
+                            .map(Bukkit::getOfflinePlayer)
                             .map(OfflinePlayer::getName)
                             .filter(Objects::nonNull)
                             .filter(player -> player.startsWith(secondArgument))
                             .sorted()
                             .collect(Collectors.toUnmodifiableList()) :
-                    plugin.getServer().getOnlinePlayers().stream()
+                    plugin.getServer().getOnlinePlayers()
+                            .stream()
                             .map(HumanEntity::getName)
                             .filter(player -> player.startsWith(secondArgument))
                             .sorted()

--- a/src/main/java/net/okocraft/databackup/command/subcommand/SearchCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/SearchCommand.java
@@ -21,10 +21,10 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -32,6 +32,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class SearchCommand extends AbstractCommand {
+
+    private static final List<String> PAGES =
+            List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                    .stream()
+                    .map(String::valueOf)
+                    .collect(Collectors.toUnmodifiableList());
 
     private final DataBackup plugin;
 
@@ -91,46 +97,44 @@ public class SearchCommand extends AbstractCommand {
         }
 
         if (args.size() == 2) {
-            Argument secondArgument = args.get(1);
+            var secondArgument = args.get(1).get();
 
             var result = offline ?
                     Stream.of(plugin.getServer().getOfflinePlayers())
                             .map(OfflinePlayer::getName)
                             .filter(Objects::nonNull)
+                            .filter(player -> player.startsWith(secondArgument))
+                            .sorted()
                             .collect(Collectors.toUnmodifiableList()) :
                     plugin.getServer().getOnlinePlayers().stream()
                             .map(HumanEntity::getName)
+                            .filter(player -> player.startsWith(secondArgument))
+                            .sorted()
                             .collect(Collectors.toList());
 
             if (!offline) {
                 result.add("offline");
             }
 
-            return StringUtil.copyPartialMatches(
-                    secondArgument.get(),
-                    result,
-                    new ArrayList<>()
-            );
+            return result;
         }
 
         if (args.size() == 3) {
-            Argument thirdArgument = args.get(2);
+            var thirdArgument = args.get(2).get();
 
-            return StringUtil.copyPartialMatches(
-                    thirdArgument.get(),
-                    Stream.of(Material.values()).map(Enum::toString).collect(Collectors.toList()),
-                    new ArrayList<>()
-            );
+            return Arrays.stream(Material.values())
+                    .map(Enum::name)
+                    .filter(material -> material.startsWith(thirdArgument))
+                    .sorted()
+                    .collect(Collectors.toUnmodifiableList());
         }
 
         if (args.size() == 4) {
-            Argument fourthArgument = args.get(3);
+            var fourthArgument = args.get(3).get();
 
-            return StringUtil.copyPartialMatches(
-                    fourthArgument.get(),
-                    List.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-                    new ArrayList<>()
-            );
+            return PAGES.stream()
+                    .filter(page -> page.startsWith(fourthArgument))
+                    .collect(Collectors.toUnmodifiableList());
         }
 
         return Collections.emptyList();

--- a/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
@@ -8,6 +8,7 @@ import com.github.siroshun09.mccommand.common.argument.Argument;
 import com.github.siroshun09.mccommand.common.context.CommandContext;
 import com.github.siroshun09.mccommand.common.sender.Sender;
 import net.okocraft.databackup.DataBackup;
+import net.okocraft.databackup.command.StartsWithIgnoreCase;
 import net.okocraft.databackup.data.DataType;
 import net.okocraft.databackup.lang.DefaultMessage;
 import net.okocraft.databackup.lang.MessageProvider;
@@ -118,7 +119,7 @@ public class ShowCommand extends AbstractCommand {
                     plugin.getDataTypeRegistry().getRegisteredDataType()
                             .stream()
                             .map(DataType::getName)
-                            .filter(str -> str.startsWith(secondArgument))
+                            .filter(StartsWithIgnoreCase.prefix(secondArgument))
                             .sorted()
                             .collect(Collectors.toList());
 
@@ -138,12 +139,12 @@ public class ShowCommand extends AbstractCommand {
                             .map(Bukkit::getOfflinePlayer)
                             .map(OfflinePlayer::getName)
                             .filter(Objects::nonNull)
-                            .filter(player -> player.startsWith(thirdArgument))
+                            .filter(StartsWithIgnoreCase.prefix(thirdArgument))
                             .sorted()
                             .collect(Collectors.toUnmodifiableList()) :
                     plugin.getServer().getOnlinePlayers().stream()
                             .map(HumanEntity::getName)
-                            .filter(player -> player.startsWith(thirdArgument))
+                            .filter(StartsWithIgnoreCase.prefix(thirdArgument))
                             .sorted()
                             .collect(Collectors.toUnmodifiableList());
         }
@@ -158,7 +159,7 @@ public class ShowCommand extends AbstractCommand {
                 return plugin.getStorage().getPlayerDataYamlFiles(target.getUniqueId())
                         .map(Path::getFileName)
                         .map(Path::toString)
-                        .filter(path -> path.startsWith(fourthArgument))
+                        .filter(StartsWithIgnoreCase.prefix(fourthArgument))
                         .sorted()
                         .collect(Collectors.toUnmodifiableList());
             }

--- a/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
@@ -15,12 +15,10 @@ import net.okocraft.databackup.lang.Placeholders;
 import net.okocraft.databackup.storage.PlayerDataFile;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.HumanEntity;
-import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -115,32 +113,37 @@ public class ShowCommand extends AbstractCommand {
         }
 
         if (args.size() == 2) {
-            Argument secondArgument = args.get(1);
+            var secondArgument = args.get(1).get();
             List<String> result =
                     plugin.getDataTypeRegistry().getRegisteredDataType()
                             .stream()
                             .map(DataType::getName)
+                            .filter(str -> str.startsWith(secondArgument))
+                            .sorted()
                             .collect(Collectors.toList());
 
             if (!offline) {
                 result.add("offline");
             }
 
-            return StringUtil.copyPartialMatches(secondArgument.get(), result, new ArrayList<>());
+            return result;
         }
 
         if (args.size() == 3) {
-            Argument thirdArgument = args.get(2);
-            List<String> result = offline ?
+            var thirdArgument = args.get(2).get();
+
+            return offline ?
                     Stream.of(plugin.getServer().getOfflinePlayers())
                             .map(OfflinePlayer::getName)
                             .filter(Objects::nonNull)
+                            .filter(player -> player.startsWith(thirdArgument))
+                            .sorted()
                             .collect(Collectors.toList()) :
                     plugin.getServer().getOnlinePlayers().stream()
                             .map(HumanEntity::getName)
+                            .filter(player -> player.startsWith(thirdArgument))
+                            .sorted()
                             .collect(Collectors.toUnmodifiableList());
-
-            return StringUtil.copyPartialMatches(thirdArgument.get(), result, new ArrayList<>());
         }
 
         if (args.size() == 4) {
@@ -148,16 +151,14 @@ public class ShowCommand extends AbstractCommand {
             OfflinePlayer target = BukkitParser.OFFLINE_PLAYER.parse(thirdArgument);
 
             if (target != null) {
-                Argument fourthArgument = args.get(3);
+                var fourthArgument = args.get(3).get();
 
-                return StringUtil.copyPartialMatches(
-                        fourthArgument.get(),
-                        plugin.getStorage().getPlayerDataYamlFiles(target.getUniqueId())
-                                .map(Path::getFileName)
-                                .map(Path::toString)
-                                .collect(Collectors.toUnmodifiableList()),
-                        new ArrayList<>()
-                );
+                return plugin.getStorage().getPlayerDataYamlFiles(target.getUniqueId())
+                        .map(Path::getFileName)
+                        .map(Path::toString)
+                        .filter(path -> path.startsWith(fourthArgument))
+                        .sorted()
+                        .collect(Collectors.toUnmodifiableList());
             }
         }
 

--- a/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
@@ -15,7 +15,6 @@ import net.okocraft.databackup.lang.Placeholders;
 import net.okocraft.databackup.storage.PlayerDataFile;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.HumanEntity;
-import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
+++ b/src/main/java/net/okocraft/databackup/command/subcommand/ShowCommand.java
@@ -13,6 +13,7 @@ import net.okocraft.databackup.lang.DefaultMessage;
 import net.okocraft.databackup.lang.MessageProvider;
 import net.okocraft.databackup.lang.Placeholders;
 import net.okocraft.databackup.storage.PlayerDataFile;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.HumanEntity;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ShowCommand extends AbstractCommand {
 
@@ -133,12 +133,14 @@ public class ShowCommand extends AbstractCommand {
             var thirdArgument = args.get(2).get();
 
             return offline ?
-                    Stream.of(plugin.getServer().getOfflinePlayers())
+                    plugin.getStorage().getBackedUpPlayers()
+                            .stream()
+                            .map(Bukkit::getOfflinePlayer)
                             .map(OfflinePlayer::getName)
                             .filter(Objects::nonNull)
                             .filter(player -> player.startsWith(thirdArgument))
                             .sorted()
-                            .collect(Collectors.toList()) :
+                            .collect(Collectors.toUnmodifiableList()) :
                     plugin.getServer().getOnlinePlayers().stream()
                             .map(HumanEntity::getName)
                             .filter(player -> player.startsWith(thirdArgument))

--- a/src/main/java/net/okocraft/databackup/lang/DefaultMessage.java
+++ b/src/main/java/net/okocraft/databackup/lang/DefaultMessage.java
@@ -19,7 +19,7 @@ public enum DefaultMessage implements com.github.siroshun09.mcmessage.message.De
     COMMAND_ROLLBACK_SENDER("command.rollback.sender", "&b%player%&7 の &b%type%&7 のデータを &b%date%&7 時点に戻しました。"),
     COMMAND_ROLLBACK_TARGET("command.rollback.target", "&b%type%&7 のデータが &b%date%&7 時点に戻されました。"),
     COMMAND_ROLLBACK_FAILURE("command.rollback.failure", "&cロールバックに失敗しました。コンソールを確認してください。"),
-    COMMAND_SEARCH_USAGE("command.search.usage", "&b/db search <target> <material> {page} - &7指定したアイテムを検索します。"),
+    COMMAND_SEARCH_USAGE("command.search.usage", "&b/db search {offline} <target> <material> {page} - &7指定したアイテムを検索します。"),
     COMMAND_SEARCH_NOT_FOUND("command.search.not-found", "&c指定した Material のアイテムは見つかりませんでした。"),
     COMMAND_SEARCH_FAILURE("command.search.failure", "&cアイテムの検索に失敗しました。コンソールを確認してください。"),
     COMMAND_SHOW_USAGE("command.show.usage", "&b/db show {offline} <type> <target> <file>&8 - &7指定したデータの内訳を表示します。"),


### PR DESCRIPTION
- `/db search offline <args>` のサポート (#6)
- オフラインプレイヤー検索のタブ補完対象を、バックアップデータが存在するプレイヤーのみに限定する (#7)
- タブ補完の処理を `Stream` で完結させる