### PR TITLE
[Fix] アイテムの保存方法を変更する

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>paper-repo</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <repository>
             <id>bintray-okocraft-maven-repo</id>

--- a/src/main/java/net/okocraft/databackup/data/impl/EnderChestData.java
+++ b/src/main/java/net/okocraft/databackup/data/impl/EnderChestData.java
@@ -77,7 +77,14 @@ public class EnderChestData implements DataType<List<ItemStack>> {
         return yaml -> {
             List<ItemStack> items = new ArrayList<>(ARRAY_LENGTH);
             for (int i = 0; i < ARRAY_LENGTH; i++) {
-                items.add(yaml.getItemStack(getName() + "." + i));
+                var oldPath = getName() + "." + i;
+                if (yaml.get(oldPath) != null) {
+                    items.add(yaml.getItemStack(oldPath));
+                } else {
+                    var data = yaml.getString(getName() + "-2." + i);
+                    var item = ItemStackSerializer.deserialize(data);
+                    items.add(item);
+                }
             }
             return ItemSearchable.createData(
                     UUIDValue.INSTANCE.getValue(yaml),
@@ -92,8 +99,9 @@ public class EnderChestData implements DataType<List<ItemStack>> {
         return (itemData, yaml) -> {
             for (int i = 0; i < ARRAY_LENGTH || i < itemData.get().size(); i++) {
                 var item = itemData.get().get(i);
-                if (!item.getType().isAir()) {
-                    yaml.set(getName() + "." + i, item);
+                var data = ItemStackSerializer.serialize(item);
+                if (!data.isEmpty()) {
+                    yaml.set(getName() + "-2." + i, data);
                 }
             }
         };

--- a/src/main/java/net/okocraft/databackup/data/impl/InventoryData.java
+++ b/src/main/java/net/okocraft/databackup/data/impl/InventoryData.java
@@ -77,7 +77,14 @@ public class InventoryData implements DataType<List<ItemStack>> {
         return yaml -> {
             List<ItemStack> items = new ArrayList<>(ARRAY_LENGTH);
             for (int i = 0; i < ARRAY_LENGTH; i++) {
-                items.add(yaml.getItemStack(getName() + "." + i));
+                var oldPath = getName() + "." + i;
+                if (yaml.get(oldPath) != null) {
+                    items.add(yaml.getItemStack(oldPath));
+                } else {
+                    var data = yaml.getString(getName() + "-2." + i);
+                    var item = ItemStackSerializer.deserialize(data);
+                    items.add(item);
+                }
             }
             return ItemSearchable.createData(
                     UUIDValue.INSTANCE.getValue(yaml),
@@ -92,8 +99,9 @@ public class InventoryData implements DataType<List<ItemStack>> {
         return (itemData, yaml) -> {
             for (int i = 0; i < ARRAY_LENGTH || i < itemData.get().size(); i++) {
                 var item = itemData.get().get(i);
-                if (!item.getType().isAir()) {
-                    yaml.set(getName() + "." + i, item);
+                var data = ItemStackSerializer.serialize(item);
+                if (!data.isEmpty()) {
+                    yaml.set(getName() + "-2." + i, data);
                 }
             }
         };

--- a/src/main/java/net/okocraft/databackup/data/impl/ItemStackSerializer.java
+++ b/src/main/java/net/okocraft/databackup/data/impl/ItemStackSerializer.java
@@ -1,0 +1,92 @@
+package net.okocraft.databackup.data.impl;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+final class ItemStackSerializer {
+
+    private static final boolean isPaper = checkPaper();
+    private static final String EMPTY = "";
+    private static final byte[] EMPTY_BYTE = new byte[0];
+    private static final ItemStack AIR = new ItemStack(Material.AIR);
+
+    static @NotNull String serialize(@NotNull ItemStack itemStack) {
+        if (itemStack.getType().isAir()) {
+            return EMPTY;
+        }
+
+        byte[] bytes;
+        if (isPaper) {
+            bytes = serializeByPaperMethod(itemStack);
+        } else {
+            bytes = serializeByBukkitMethod(itemStack);
+        }
+
+        if (bytes.length != 0) {
+            return Base64.getEncoder().encodeToString(bytes);
+        } else {
+            return EMPTY;
+        }
+    }
+
+    static @NotNull ItemStack deserialize(@NotNull String data) {
+        if (data.isEmpty()) {
+            return AIR;
+        }
+
+        var bytes = Base64.getDecoder().decode(data);
+
+        if (isPaper) {
+            return deserializeByPaperMethod(bytes);
+        } else {
+            return deserializeByBukkitMethod(bytes);
+        }
+    }
+
+    private static byte[] serializeByPaperMethod(@NotNull ItemStack itemStack) {
+        return itemStack.serializeAsBytes();
+    }
+
+    private static byte[] serializeByBukkitMethod(@NotNull ItemStack itemStack) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream)) {
+            dataOutput.writeObject(itemStack);
+            return outputStream.toByteArray();
+        } catch (IOException | IllegalStateException e) {
+            e.printStackTrace();
+            return EMPTY_BYTE;
+        }
+    }
+
+    private static @NotNull ItemStack deserializeByPaperMethod(byte[] bytes) {
+        return ItemStack.deserializeBytes(bytes);
+    }
+
+    private static @NotNull ItemStack deserializeByBukkitMethod(byte[] bytes) {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream)) {
+            return (ItemStack) dataInput.readObject();
+        } catch (ClassNotFoundException | IOException e) {
+            e.printStackTrace();
+            return AIR;
+        }
+    }
+
+    private static boolean checkPaper() {
+        try {
+            ItemStack.class.getMethod("serializeAsBytes");
+            ItemStack.class.getMethod("deserializeBytes", byte[].class);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Bukkit の `ConfigurationSerializable#serialize` で保存すると、主にアイテム名や lore で保存前と保存後で差異が生じるため、Paper で稼働している場合に限り、Paper で追加されている `ItemStack#serializeAsBytes` でシリアライズする。

Bukkit (Spigot) 上では `BukkitObjectOutputStream` を使用してバイトにする。ただし、この方法は内部的に `ConfigurationSerializable#serialize` が使用されているため、上記の問題は解決しない。

yaml には Base64 でエンコードした文字列で保存される。
なお、この変更前のバックアップファイルの読み込みはサポートされる。
無用なバグを防ぐため、新しく保存されるインベントリとエンダーチェストの保存キーには接尾に `-2` をつけている。

さらに、Paper と Bukkit でエンコード方法が異なるため、Base64 でエンコードした文字列の接頭辞として `PAPER-` `BUKKIT-` がつけられ、区別される。
これにより、Bukkit (Spigot) から Paper (とそのフォーク) にサーバーソフトウェアを変更した場合でも、バックアップファイルを読み込めるようにする。ただしその逆は不可能。




